### PR TITLE
Add 2nd Lavalink node (minatoaqua.miraclecherrypie.cf with port 8880)

### DIFF
--- a/docs/NoSSL/lavalink-without-ssl.md
+++ b/docs/NoSSL/lavalink-without-ssl.md
@@ -189,3 +189,11 @@ Port : 80
 Password : "oxygen"
 Secure : false
 ```
+
+Hosted by @ [MiracleCherryPie](https://github.com/MiracleCherryPie)
+```bash
+Host : minatoaqua.miraclecherrypie.cf
+Port: 8880
+Password : "KawaiiOnyanisbetter!!!!"
+Secure : false
+```


### PR DESCRIPTION
If you wonder why it have same domain with different port, it's just because this one is SSH tunneled (you can see the difference at the RAM usage).