### PR TITLE
Removal of instances

### DIFF
--- a/docs/SSL/lavalink-with-ssl.md
+++ b/docs/SSL/lavalink-with-ssl.md
@@ -7,46 +7,6 @@ description: SSL Uses Secure WS connection, whilst No SSL uses standard WS. if y
 <div data-ea-style="stickybox" class="dark horizontal" data-ea-publisher="darrennathanaelcom" data-ea-type="image"></div>
 
 
-Hosted by @ [OGGY#9889](https://www.freelavalink.ga)
-```bash
-Host : ssl.freelavalink.ga
-Port : 443
-Password : "www.freelavalink.ga"
-Secure : true
-```
-
-Hosted by @ [ErrorDoc404](https://github.com/ErrorDoc404)
-```bash
-Host : node1.kartadharta.xyz
-Port : 443
-Password : "kdlavalink"
-secure : true
-```
-
-Hosted by @ [Islantay](https://github.com/Dep0s1t)
-```bash
-Host : jp-lava.islantay.tk
-Port : 443
-Password : "AmeliaWatsonisTheBest**!"
-Secure : true
-```
-
-Hosted by @ [MathisCool#8659, AceTheAwesome#3366](https://lavalink-list.botsuniversity.ml)
-```bash
-Host : lavalink.botsuniversity.ml
-Port : 443
-Password : "mathiscool"
-Secure : true
-```
-
-Hosted by @ [MathisCool#8659, AceTheAwesome#3366](https://lavalink-list.botsuniversity.ml)
-```bash
-Host : lavalink2.botsuniversity.ml
-Port : 443
-Password : "mathiscool"
-Secure : true
-```
-
 Hosted by @ [melike2d](https://2d.gay)
 ```bash
 Host : krn.2d.gay


### PR DESCRIPTION
First 5 servers are offline/uses outdated version.

Possible causes:
 * Free TLDs .tk/.cf/.ga/.ml/.gq are now impossible to obtain.
 * Their (/metrics) endpoint are inaccessible.