### PR TITLE
Update lavalink-with-ssl.md

### DIFF
--- a/docs/SSL/lavalink-with-ssl.md
+++ b/docs/SSL/lavalink-with-ssl.md
@@ -38,12 +38,12 @@ Password : "lexn3tl@val!nk"
 Secure : true
 ```
 
-### Hosted by Nep
+### Hosted by @ [Nep](https://youtu.be/3u2xm9Oifa4)
 Version 3.7.8
 
 Check uptime [here](https://xiaoer.info.gf/status/node)
 ```bash
-Host : lavalink.pii.at
+Host : lava.dcmusic.ca
 Port : 443
 Password : "youshallnotpass"
 Secure : true


### PR DESCRIPTION
old domain somehow lost its issued certs. renewed and switched to Let's Encrypt!