### PR TITLE
Add "Penacony" to the SSL list

### DIFF
--- a/docs/SSL/lavalink-with-ssl.md
+++ b/docs/SSL/lavalink-with-ssl.md
@@ -110,3 +110,20 @@ Port : 443
 Password : "catfein"
 Secure : true
 ```
+
+### Hosted by @ [Miruku](https://github.com/sprucecellodev125)
+Version 3.7.10
+```bash
+Host : penacony.hehe.rest
+Port : 443
+Password : "youshallnotpass"
+Secure : true
+```
+
+Version 4.0.3
+```bash
+Host : penacony4.hehe.rest
+Port : 443
+Password : "youshallnotpass"
+Secure : true
+```


### PR DESCRIPTION
Note: this Lavalink server is hosted in Asia
Adding:
- Penacony (main Lavalink server)
- Penacony v4 (v4 compatibility server)