### PR TITLE
Update lavalink-without-ssl.md

### DIFF
--- a/docs/NoSSL/lavalink-without-ssl.md
+++ b/docs/NoSSL/lavalink-without-ssl.md
@@ -19,6 +19,16 @@ hide:
     v4 introduce a breaking changes that affects all library that are using v3 API.
     You must update your bot library to support v4!
 
+
+### Hosted by @ [Reedorux Node](https://discord.gg/eevx6hyDVC)
+Version 4.x (Plugin),
+```bash
+Host : 89.58.5.180
+Port : 20906
+Password : "reedrouxv4lavalink"
+Secure : false
+```
+
 ### Hosted by @ [Lunar Nodes](https://lunarnodes.xyz)
 Version 4.0.5 (Plugin), DE, Mühlhausen
 ```bash


### PR DESCRIPTION
Add 

### Hosted by @ [Reedorux Node](https://discord.gg/eevx6hyDVC)
Version 4.x (Plugin),
```bash
Host : 89.58.5.180
Port : 20906
Password : "reedrouxv4lavalink"
Secure : false