### PR TITLE
Update lavalink-without-ssl.md

### DIFF
--- a/docs/NoSSL/lavalink-without-ssl.md
+++ b/docs/NoSSL/lavalink-without-ssl.md
@@ -23,6 +23,7 @@ hide:
 
 ### Hosted by @ [Cloud Reedroux](https://reedroux.biz/)
 Version 4.x
+[Live Status](https://hetrixtools.com/r/530af032379fc83316a8221a44a8cd52/) 
 ```bash
 Host : 37.27.114.136
 Port : 25065


### PR DESCRIPTION
added on my lavalink a status site 

[Live Status](https://hetrixtools.com/r/530af032379fc83316a8221a44a8cd52/) 
