### PR TITLE
Update lavalink-without-ssl.md

### DIFF
--- a/docs/NoSSL/lavalink-without-ssl.md
+++ b/docs/NoSSL/lavalink-without-ssl.md
@@ -57,6 +57,17 @@ Password : "youshallnotpass"
 Secure : false
 ```
 
+### Hosted by @ [LewdHuTao](https://github.com/lewdhutao)
+Version 4.x 
+<br>
+[![Uptime](https://uptime.betterstack.com/status-badges/v2/monitor/1imje.svg)](https://uptime.betterstack.com/?utm_source=status_badge) ![Node Players](https://lavalink.shittybot.xyz/api/v1/badge/3)
+```bash
+Host : node.lewdhutao.my.eu.org
+Port : 80
+Password : "youshallnotpass"
+Secure : false
+```
+
 ### Hosted by @ [Lunar Nodes](https://lunarnodes.xyz)
 Version 4.0.5 (Plugin), DE, Mühlhausen
 ```bash


### PR DESCRIPTION
Add no-ssl lavalink hosted in Asia (Singapore).

Sources: Youtube, Apple music, Deezer, Spotify and more

Node Details:
```json
{
    "version": {
        "semver": "4.0.7",
        "major": 4,
        "minor": 0,
        "patch": 7,
        "preRelease": ""
    },
    "buildTime": 1720476857034,
    "git": {
        "branch": "HEAD",
        "commit": "93102f8",
        "commitTime": 1720475342000
    },
    "jvm": "21.0.4",
    "lavaplayer": "2.2.1",
    "sourceManagers": [
        "soundcloud",
        "bandcamp",
        "twitch",
        "vimeo",
        "niconico",
        "youtube",
        "spotify",
        "applemusic",
        "deezer",
        "http"
    ],
    "filters": [
        "volume",
        "equalizer",
        "karaoke",
        "timescale",
        "tremolo",
        "vibrato",
        "distortion",
        "rotation",
        "channelMix",
        "lowPass"
    ],
    "plugins": [
        {
            "name": "youtube-plugin",
            "version": "1.7.1"
        },
        {
            "name": "lavasrc-plugin",
            "version": "4.2.0"
        }
    ]
}
```