### PR TITLE
Update Lavalink-SSL.md to remove obsolete content

### DIFF
--- a/docs/SSL/Lavalink-SSL.md
+++ b/docs/SSL/Lavalink-SSL.md
@@ -56,7 +56,7 @@ Secure : true
 ```
 
 ### Hosted by @ [TriniumHost](https://triniumhost.com)
-[Live Stats](https://lavalink-status.triniumhost.com) | [Support](lavalink-status.triniumhost.com/suporte) | [Arthur Website](https://adssousag.is-a.dev/)
+[Live Stats](https://lavalink-status.triniumhost.com) | [Support](https://lavalink-status.triniumhost.com/suporte) | [Arthur Website](https://adssousag.is-a.dev/)
 
 Version 4.x.x
 

--- a/docs/SSL/Lavalink-SSL.md
+++ b/docs/SSL/Lavalink-SSL.md
@@ -67,13 +67,3 @@ Port : 443
 Password : "free"
 Secure : true
 ```
-
-Version 3.x.x
-
-![Status](https://lavalink-api-status.triniumhost.com/v3ssl/badge/status) ![Load](https://lavalink-api-status.triniumhost.com/v3ssl/badge/load) ![Players](https://lavalink-api-status.triniumhost.com/v3ssl/badge/connections)
-```bash
-Host : lavalink-v3.triniumhost.com
-Port : 443
-Password : "free"
-Secure : true
-```


### PR DESCRIPTION
Removed outdated version information and status badges from Lavalink-SSL documentation.